### PR TITLE
Add functional toArray(IntFunction) to FastStream.

### DIFF
--- a/src/main/java/net/covers1624/quack/collection/FastStream.java
+++ b/src/main/java/net/covers1624/quack/collection/FastStream.java
@@ -1224,6 +1224,23 @@ public interface FastStream<T> extends Iterable<T> {
     }
 
     /**
+     * Collects the stream into a {@code T}[].
+     * <p>
+     * In most cases, implementations of this function only query the supplied function
+     * with a size of {@code 0} to inspect the array type, this mirrors how base Java collections
+     * implement this function. Some {@link FastStream} implementations may choose to
+     * call the supplied function with an exact size. The supplied function is expected
+     * to honor this request and return a correctly sized array.
+     *
+     * @param func The function to construct a new array instance of the
+     *             desired type and length.
+     * @return An array of elements.
+     */
+    default T[] toArray(IntFunction<T[]> func) {
+        return toArray(func.apply(0));
+    }
+
+    /**
      * Collects this stream into a {@link HashMap}.
      * <p>
      * In the event of a collision, the first value will be used.
@@ -2229,6 +2246,7 @@ public interface FastStream<T> extends Iterable<T> {
             @Override public ImmutableSet<T> toImmutableSet() { return ImmutableSet.of(); }
             @Override public Object[] toArray() { return new Object[0]; }
             @Override public T[] toArray(T[] arr) { return ColUtils.fill(arr, null); }
+            @Override public T[] toArray(IntFunction<T[]> func) { return func.apply(0); }
             @Override public <K, V> HashMap<K, V> toMap(Function<? super T, ? extends K> kFunc, Function<? super T, ? extends V> vFunc) { return new HashMap<>(); }
             @Override public <K, V> HashMap<K, V> toMap(Function<? super T, ? extends K> kFunc, Function<? super T, ? extends V> vFunc, BinaryOperator<V> mergeFunc) { return new HashMap<>(); }
             @Override public <K, V> LinkedHashMap<K, V> toLinkedHashMap(Function<? super T, ? extends K> kFunc, Function<? super T, ? extends V> vFunc) { return new LinkedHashMap<>(); }

--- a/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
+++ b/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
@@ -184,20 +184,25 @@ public class FastStreamTests {
     @Test
     public void testToArray() {
         Object[] objectArray = FastStream.of("a", "b", "c", "d").toArray();
-
         assertEquals(4, objectArray.length);
         assertEquals("a", objectArray[0]);
         assertEquals("b", objectArray[1]);
         assertEquals("c", objectArray[2]);
         assertEquals("d", objectArray[3]);
 
-        Object[] stringArray = FastStream.of("a", "b", "c", "d").toArray(new String[0]);
-
+        String[] stringArray = FastStream.of("a", "b", "c", "d").toArray(new String[0]);
         assertEquals(4, stringArray.length);
         assertEquals("a", stringArray[0]);
         assertEquals("b", stringArray[1]);
         assertEquals("c", stringArray[2]);
         assertEquals("d", stringArray[3]);
+
+        String[] specificArray = FastStream.of("a", "b", "c", "d").toArray(String[]::new);
+        assertEquals(4, specificArray.length);
+        assertEquals("a", specificArray[0]);
+        assertEquals("b", specificArray[1]);
+        assertEquals("c", specificArray[2]);
+        assertEquals("d", specificArray[3]);
     }
 
     @Test


### PR DESCRIPTION
This brings some more parity between `Stream` and Java11+ `Collection` which has a similar function.