### PR TITLE
Implement partitioning support for FastStream.

### DIFF
--- a/src/main/java/net/covers1624/quack/collection/FastStream.java
+++ b/src/main/java/net/covers1624/quack/collection/FastStream.java
@@ -313,7 +313,7 @@ public interface FastStream<T> extends Iterable<T> {
      * @param amount The amount to store in each bucket.
      * @return The partitioned {@link FastStream}
      */
-    default FastStream<Bucket<T>> partition(int amount) {
+    default FastStream<FastStream<T>> partition(int amount) {
         return new Partitioned<>(this, amount);
     }
 
@@ -1975,7 +1975,7 @@ public interface FastStream<T> extends Iterable<T> {
     /**
      * A {@link FastStream} of elements grouped into buckets of a specific size.
      */
-    final class Partitioned<V> implements FastStream<Bucket<V>> {
+    final class Partitioned<V> implements FastStream<FastStream<V>> {
 
         private final FastStream<V> parent;
         private final int amount;
@@ -1988,12 +1988,12 @@ public interface FastStream<T> extends Iterable<T> {
         }
 
         @Override
-        public Iterator<Bucket<V>> iterator() {
+        public Iterator<FastStream<V>> iterator() {
             return ColUtils.iterator(buckets());
         }
 
         @Override
-        public void forEach(Consumer<? super Bucket<V>> action) {
+        public void forEach(Consumer<? super FastStream<V>> action) {
             for (Bucket<V> bucket : buckets()) {
                 action.accept(bucket);
             }

--- a/src/main/java/net/covers1624/quack/net/httpapi/okhttp/OkHttpEngineRequest.java
+++ b/src/main/java/net/covers1624/quack/net/httpapi/okhttp/OkHttpEngineRequest.java
@@ -13,7 +13,6 @@ import okhttp3.Response;
 import okio.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import sun.net.ProgressListener;
 
 import java.io.IOException;
 

--- a/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
+++ b/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -386,6 +385,21 @@ public class FastStreamTests {
         assertCollectionEquals(grouped.get('a'), "apple");
         assertCollectionEquals(grouped.get('b'), "banana", "boat");
         assertCollectionEquals(grouped.get('p'), "pair", "pool");
+    }
+
+    @Test
+    public void testPartition() {
+        List<String> b0 = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
+        List<String> b1 = Arrays.asList("k", "l", "m", "n", "o", "p", "q", "r", "s", "t");
+        List<String> b2 = Arrays.asList("u", "v", "w", "x", "y", "z");
+        List<List<String>> partitioned = FastStream.of(b0, b1, b2).flatMap(e -> e)
+                .partition(10)
+                .map(FastStream::toList)
+                .toList(FastStream.infer());
+        assertEquals(3, partitioned.size());
+        assertEquals(b0, partitioned.get(0));
+        assertEquals(b1, partitioned.get(1));
+        assertEquals(b2, partitioned.get(2));
     }
 
     @Test


### PR DESCRIPTION
Implements support for 'partitioning' a `FastStream` into sub-streams of a given size.

Guava has similar functions for Lists which are very useful.