### PR TITLE
Implement more FastStream ops.

### DIFF
--- a/src/main/java/net/covers1624/quack/collection/FastStream.java
+++ b/src/main/java/net/covers1624/quack/collection/FastStream.java
@@ -290,6 +290,19 @@ public interface FastStream<T> extends Iterable<T> {
 
     /**
      * Returns a {@link FastStream} with each element transformed by
+     * the provided {@link Function}, filtering any null mapped elements from the stream.
+     * <p>
+     * This is useful for standard nullable matching operations.
+     *
+     * @param func The {@link Function} to apply.
+     * @return The transformed and null filtered {@link FastStream}.
+     */
+    default <R> FastStream<@NonNull R> mapNonNull(Function<? super T, ? extends @Nullable R> func) {
+        return this.<R>map(func).filterNonNull();
+    }
+
+    /**
+     * Returns a {@link FastStream} with each element transformed by
      * the provided {@link Function} concatenated together.
      *
      * @param func The {@link Function} to apply producing the {@link Iterable} for concatenation.

--- a/src/main/java/net/covers1624/quack/collection/FastStream.java
+++ b/src/main/java/net/covers1624/quack/collection/FastStream.java
@@ -278,6 +278,17 @@ public interface FastStream<T> extends Iterable<T> {
     }
 
     /**
+     * Returns a {@link FastStream} with all elements filtered to instances
+     * of the provided class.
+     *
+     * @param clazz The class to filter by.
+     * @return The transformed {@link FastStream}
+     */
+    default <R> FastStream<@NonNull R> ofType(Class<? extends R> clazz) {
+        return new OfType<>(this, clazz);
+    }
+
+    /**
      * Returns a {@link FastStream} with each element transformed by
      * the provided {@link Function} concatenated together.
      *
@@ -1845,6 +1856,47 @@ public interface FastStream<T> extends Iterable<T> {
             return parent.knownLength(consumeToCalculate);
         }
 
+    }
+
+    /**
+     * A {@link FastStream} with a type filter and mapping applied.
+     */
+    final class OfType<T, R> implements FastStream<R> {
+
+        private final FastStream<T> parent;
+        private final Class<? extends R> clazz;
+
+        public OfType(FastStream<T> parent, Class<? extends R> clazz) {
+            this.parent = parent;
+            this.clazz = clazz;
+        }
+
+        @Override
+        public Iterator<R> iterator() {
+            return new AbstractIterator<R>() {
+                private final Iterator<T> itr = parent.iterator();
+
+                @Override
+                protected R computeNext() {
+                    while (itr.hasNext()) {
+                        T e = itr.next();
+                        if (clazz.isInstance(e)) {
+                            return clazz.cast(e);
+                        }
+                    }
+                    return endOfData();
+                }
+            };
+        }
+
+        @Override
+        public void forEach(Consumer<? super R> action) {
+            parent.forEach(e -> {
+                if (clazz.isInstance(e)) {
+                    action.accept(clazz.cast(e));
+                }
+            });
+        }
     }
 
     /**

--- a/src/main/java/net/covers1624/quack/collection/FastStream.java
+++ b/src/main/java/net/covers1624/quack/collection/FastStream.java
@@ -423,6 +423,54 @@ public interface FastStream<T> extends Iterable<T> {
 
         return new Sliced<>(this, n, Integer.MAX_VALUE);
     }
+
+    /**
+     * Returns a {@link FastStream} which will only contain elements
+     * up to the first element that fails the given {@link Predicate}.
+     *
+     * @param pred The predicate.
+     * @return The filtered {@link FastStream}.
+     */
+    default FastStream<T> takeWhile(Predicate<? super T> pred) {
+        return new TakenWhile<>(this, pred);
+    }
+
+    /**
+     * Returns a {@link FastStream} which will only contain elements
+     * up to the first element which passes the given {@link Predicate}.
+     * <p>
+     * This is the condition inverted form of {@link #takeWhile}.
+     *
+     * @param pred The predicate.
+     * @return The filtered {@link FastStream}.
+     */
+    default FastStream<T> takeUntil(Predicate<? super T> pred) {
+        return takeWhile(pred.negate());
+    }
+
+    /**
+     * Returns a {@link FastStream} which will not contain any elements until
+     * the given {@link Predicate} fails once.
+     *
+     * @param pred The predicate.
+     * @return The filtered {@link FastStream}.
+     */
+    default FastStream<T> dropWhile(Predicate<? super T> pred) {
+        return new DroppedWhile<>(this, pred);
+    }
+
+    /**
+     * Returns a {@link FastStream} which will not contain any elements until
+     * the given {@link Predicate} passes once.
+     * <p>
+     * This is the inverted form of {@link #dropWhile}
+     *
+     * @param pred The predicate.
+     * @return The filtered {@link FastStream}.
+     */
+    default FastStream<T> dropUntil(Predicate<? super T> pred) {
+        return dropWhile(pred.negate());
+    }
     // endregion
 
     // region Queries.
@@ -2427,6 +2475,105 @@ public interface FastStream<T> extends Iterable<T> {
             if (pLen == -1) return -1;
 
             return Math.min(Math.max(pLen - min, 0), max);
+        }
+    }
+
+    /**
+     * A {@link FastStream} which returns elements whilst the predicate matches, then stops.
+     */
+    final class TakenWhile<T> implements FastStream<T> {
+
+        private final FastStream<T> parent;
+        private final Predicate<? super T> pred;
+
+        private TakenWhile(FastStream<T> parent, Predicate<? super T> pred) {
+            this.parent = parent;
+            this.pred = pred;
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return new AbstractIterator<T>() {
+                private final Iterator<T> itr = parent.iterator();
+
+                @Override
+                protected @Nullable T computeNext() {
+                    if (itr.hasNext()) {
+                        T val = itr.next();
+                        if (pred.test(val)) {
+                            return val;
+                        }
+                    }
+                    return endOfData();
+                }
+            };
+        }
+
+        @Override
+        public void forEach(Consumer<? super T> action) {
+            ForEachAbort abort = new ForEachAbort();
+            try {
+                parent.forEach(e -> {
+                    if (!pred.test(e)) throw abort;
+
+                    action.accept(e);
+                });
+            } catch (ForEachAbort ex) {
+                if (ex != abort) {
+                    throw ex;
+                }
+            }
+        }
+    }
+
+    /**
+     * A {@link FastStream} which ignores elements whilst the predicate matches, then returns everything else.
+     */
+    final class DroppedWhile<T> implements FastStream<T> {
+
+        private final FastStream<T> parent;
+        private final Predicate<? super T> pred;
+
+        private DroppedWhile(FastStream<T> parent, Predicate<? super T> pred) {
+            this.parent = parent;
+            this.pred = pred;
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return new AbstractIterator<T>() {
+                private boolean stopDropping;
+                private final Iterator<T> itr = parent.iterator();
+
+                @Override
+                protected @Nullable T computeNext() {
+                    while (itr.hasNext()) {
+                        T val = itr.next();
+                        if (stopDropping || !pred.test(val)) {
+                            stopDropping = true;
+                            return val;
+                        }
+                    }
+                    return endOfData();
+                }
+            };
+        }
+
+        @Override
+        public void forEach(Consumer<? super T> action) {
+            class Cons implements Consumer<T> {
+
+                boolean stopDropping;
+
+                @Override
+                public void accept(T t) {
+                    if (stopDropping || !pred.test(t)) {
+                        stopDropping = true;
+                        action.accept(t);
+                    }
+                }
+            }
+            parent.forEach(new Cons());
         }
     }
     // endregion

--- a/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
+++ b/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
@@ -474,6 +474,14 @@ public class FastStreamTests {
         assertEquals("d", entries.get(3));
     }
 
+    @Test
+    public void testOfType() {
+        List<Object> list = ImmutableList.of("a", 1, 1F, "b", 2, 2F, "c", 3, 3F, "d", 4, 4F);
+        assertStreamEquals(ImmutableList.of(1, 2, 3, 4), () -> FastStream.of(list).ofType(Integer.class));
+        assertStreamEquals(ImmutableList.of(1, 1F, 2, 2F, 3, 3F, 4, 4F), () -> FastStream.of(list).ofType(Number.class));
+        assertStreamEquals(ImmutableList.of("a", "b", "c", "d"), () -> FastStream.of(list).ofType(String.class));
+    }
+
     private <T> void assertStreamEquals(List<T> expected, Supplier<FastStream<T>> stream) {
         assertEquals(expected.size(), stream.get().count());
         assertEquals(expected, stream.get().toList());

--- a/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
+++ b/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
@@ -482,6 +482,14 @@ public class FastStreamTests {
         assertStreamEquals(ImmutableList.of("a", "b", "c", "d"), () -> FastStream.of(list).ofType(String.class));
     }
 
+    @Test
+    public void testMapNonNull() {
+        List<Object> list = ImmutableList.of("a", 1, 1F, "b", 2, 2F, "c", 3, 3F, "d", 4, 4F);
+        assertStreamEquals(ImmutableList.of(1, 2, 3, 4), () -> FastStream.of(list).mapNonNull(e -> e instanceof Integer ? ((Integer) e) : null));
+        assertStreamEquals(ImmutableList.of(1, 1F, 2, 2F, 3, 3F, 4, 4F), () -> FastStream.of(list).mapNonNull(e -> e instanceof Number ? ((Number) e) : null));
+        assertStreamEquals(ImmutableList.of("a", "b", "c", "d"), () -> FastStream.of(list).mapNonNull(e -> e instanceof String ? ((String) e) : null));
+    }
+
     private <T> void assertStreamEquals(List<T> expected, Supplier<FastStream<T>> stream) {
         assertEquals(expected.size(), stream.get().count());
         assertEquals(expected, stream.get().toList());

--- a/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
+++ b/src/test/java/net/covers1624/quack/collection/FastStreamTests.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -488,6 +490,22 @@ public class FastStreamTests {
         assertStreamEquals(ImmutableList.of(1, 2, 3, 4), () -> FastStream.of(list).mapNonNull(e -> e instanceof Integer ? ((Integer) e) : null));
         assertStreamEquals(ImmutableList.of(1, 1F, 2, 2F, 3, 3F, 4, 4F), () -> FastStream.of(list).mapNonNull(e -> e instanceof Number ? ((Number) e) : null));
         assertStreamEquals(ImmutableList.of("a", "b", "c", "d"), () -> FastStream.of(list).mapNonNull(e -> e instanceof String ? ((String) e) : null));
+    }
+
+    @Test
+    public void testTakeWhileUntil() {
+        List<Integer> zeroToTwenty = IntStream.rangeClosed(0, 20).boxed().collect(Collectors.toList());
+        List<Integer> zeroToTen = IntStream.rangeClosed(0, 10).boxed().collect(Collectors.toList());
+        assertStreamEquals(zeroToTen, () -> FastStream.of(zeroToTwenty).takeWhile(e -> e <= 10));
+        assertStreamEquals(zeroToTen, () -> FastStream.of(zeroToTwenty).takeUntil(e -> e > 10));
+    }
+
+    @Test
+    public void testDropWhileUntil() {
+        List<Integer> zeroToTwenty = IntStream.rangeClosed(0, 20).boxed().collect(Collectors.toList());
+        List<Integer> tenToTwenty = IntStream.rangeClosed(10, 20).boxed().collect(Collectors.toList());
+        assertStreamEquals(tenToTwenty, () -> FastStream.of(zeroToTwenty).dropWhile(e -> e < 10));
+        assertStreamEquals(tenToTwenty, () -> FastStream.of(zeroToTwenty).dropUntil(e -> e >= 10));
     }
 
     private <T> void assertStreamEquals(List<T> expected, Supplier<FastStream<T>> stream) {


### PR DESCRIPTION
- `FastStream.ofType(Class)` for filtering and mapping the while stream to specif types.
- `FastStream.mapNonNull` for applying a nullable mapping function, returning only non-null matches.
- `FastStream.takeWhile`/`FastStream.takeUntil` and `FastStream.dropWhile`/`FastStream.dropUntil`, as general stream partitioning operations.